### PR TITLE
fix: ci补充 mkdocs.yml 路径到 sparse-checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
             fetch-depth: 0
             sparse-checkout: |
               docs
+              mkdocs.yml
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'


### PR DESCRIPTION
mkdocs.yml 位于仓库根目录，ci仅 checkout docs 目录可能导致构建失败